### PR TITLE
allow skipping cert verification

### DIFF
--- a/duo/provider.go
+++ b/duo/provider.go
@@ -29,6 +29,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("DUO_API_HOST", nil),
 				Description: "Duo AdminAPI Integration API Server",
 			},
+			"insecure": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("DUO_INSECURE", false),
+				Description: "Whether to verify the server's certificate chain and host name",
+			},
 		},
 		ConfigureFunc: providerConfigure,
 		ResourcesMap: map[string]*schema.Resource{
@@ -55,12 +61,23 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	ikey := d.Get("ikey").(string)
 	apiHost := d.Get("api_host").(string)
 
-	duoClient := duoapi.NewDuoApi(
-		ikey,
-		skey,
-		apiHost,
-		"terraform-provider-duo",
-	)
+	var duoClient *duoapi.DuoApi
+	if d.Get("insecure").(bool) {
+		duoClient = duoapi.NewDuoApi(
+			ikey,
+			skey,
+			apiHost,
+			"terraform-provider-duo",
+			duoapi.SetInsecure(),
+		)
+	} else {
+		duoClient = duoapi.NewDuoApi(
+			ikey,
+			skey,
+			apiHost,
+			"terraform-provider-duo",
+		)
+	}
 	return duoClient, nil
 }
 


### PR DESCRIPTION
This ability exists within the [Duo Go client already](https://github.com/duosecurity/duo_api_golang/blob/6c680f768e746ca8563c19035adfd94a4a4101f1/duoapi.go#L107-L111) and will aid in local testing of the provider against a mocked Duo endpoint as well as other testing.